### PR TITLE
Set compat bounds for CImGui

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
-CImGui = "1.82"
+CImGui = "~1.82"
 ImGuiGLFWBackend = "0.1"
 ImGuiOpenGLBackend = "0.1"
 ColorTypes = "0.10, 0.11"


### PR DESCRIPTION
CImGui major/minor versions follow upstream ImGui, so minor version updates may be breaking. This only allows patch updates.

(making the PR because there's a new breaking release: https://github.com/Gnimuc/CImGui.jl/releases/tag/v1.89.0)